### PR TITLE
Remove legacy driver from workstation

### DIFF
--- a/hosts/werkstatt-workstation/nvidia.nix
+++ b/hosts/werkstatt-workstation/nvidia.nix
@@ -1,16 +1,12 @@
-{ config, ... }: {
-  hardware.graphics = {
-    enable = true;
-  };
+{ ... }: {
+  hardware.graphics.enable = true;
 
   services.xserver.videoDrivers = ["nvidia"];
 
   hardware.nvidia = {
     modesetting.enable = true;
     powerManagement.enable = false;
-    #powerManagement.finegrained = false;
-    open = false;
+    open = true;
     nvidiaSettings = true;
-    package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
   };
 }


### PR DESCRIPTION
Without explicitly pinning the package, workstation will use the latest stable available driver from nixpkgs.